### PR TITLE
Haskell Fold fails to set up folding.

### DIFF
--- a/plugin/haskellFold.vim
+++ b/plugin/haskellFold.vim
@@ -101,6 +101,6 @@ endfunction "}}}
 
 augroup HaskellFold
     au!
-    au FileType Haskell call s:setHaskellFolding()
+    au FileType haskell call s:setHaskellFolding()
 augroup END
 


### PR DESCRIPTION
The file type for Haskell is lowercase "haskell" as with all the other languages. Folding failed to set up with the file type being capitalized ("Haskell").

Tested with Vim 7.3.
