### PR TITLE
Fix for issue 5 - 'ignorecase' flag

### DIFF
--- a/plugin/haskellFold.vim
+++ b/plugin/haskellFold.vim
@@ -17,19 +17,19 @@ let g:__HASKELLFOLD_VIM__ = 1
 
 " Top level bigdefs
 fun! s:HaskellFoldMaster( line ) "{{{
-    return a:line =~ '^data\s'
-      \ || a:line =~ '^type\s'
-      \ || a:line =~ '^newdata\s'
-      \ || a:line =~ '^class\s'
-      \ || a:line =~ '^instance\s'
-      \ || a:line =~ '^[^:]\+\s*::'
+    return a:line =~# '^data\s'
+      \ || a:line =~# '^type\s'
+      \ || a:line =~# '^newdata\s'
+      \ || a:line =~# '^class\s'
+      \ || a:line =~# '^instance\s'
+      \ || a:line =~  '^[^:]\+\s*::'
 endfunction "}}}
 
 " Top Level one line shooters.
 fun! s:HaskellSnipGlobal(line) "{{{
-    return a:line =~ '^module'
-      \ || a:line =~ '^import'
-      \ || a:line =~ '^infix[lr]\s'
+    return a:line =~# '^module'
+      \ || a:line =~# '^import'
+      \ || a:line =~# '^infix[lr]\s'
 endfunction "}}}
 
 " The real folding function


### PR DESCRIPTION
https://github.com/Twinside/vim-haskellFold/issues/5
Changed eval-=~ operator to eval-=~#, because latter ignores 'ignorecase' flag. This way lines, starting with 'Module' are not considered separate fold.
Haddock header is now correctly folded
![ignorecase_bug_fix](https://cloud.githubusercontent.com/assets/5804169/3004395/40232846-dd98-11e3-9aa6-e12b1c9f6c8d.png)
